### PR TITLE
fix for repeated service-IDs

### DIFF
--- a/sd_entries.lua
+++ b/sd_entries.lua
@@ -52,8 +52,8 @@ function p_sd_ents.dissector(buf,pinfo,root)
             info_col = info_col .. e_types[e_type_u8] .. ", "
         else
             info_col = info_col .. e_negative_types[e_type_u8] .. ", "
-        offset = offset + i_parse
         end
+        offset = offset + i_parse
     end
 
     if (info_col ~= "") then


### PR DESCRIPTION
For an IP-message containing several OFFER-entries, in the 'EntriesArray' for all entries the 1. detected 'Service ID' was shown.
So the number of entries is correct, but the IDs were not.

The 'offset'-index was not increased in the 'if'-path.

IP-message:
OFFER A
OFFER B

'EntriesArray':
Service ID: A
Service ID: A